### PR TITLE
Fixing under/over linking, changelog format

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ libopx_nas_qos_la_SOURCES=src/nas_qos_cps_map_entry.cpp src/nas_qos_policer.cpp 
 libopx_nas_qos_la_CPPFLAGS=-D_FILE_OFFSET_BITS=64 -I$(top_srcdir)/inc/opx -I$(includedir)/opx
 libopx_nas_qos_la_CXXFLAGS=-std=c++11
 libopx_nas_qos_la_LDFLAGS=-shared -version-info 1:1:0
-libopx_nas_qos_la_LIBADD=-lopx_logging -lopx_nas_ndi -lopx_cps_class_map -lopx_cps_api_common -lopx_common
+libopx_nas_qos_la_LIBADD=-lopx_logging -lopx_nas_ndi -lopx_cps_api_common -lopx_common -lopx_nas_common
 
 systemdconfdir=/lib/systemd/system
 systemdconf_DATA = scripts/init/*.service

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
 libopx-nas-qos (1.0.1) main; urgency=medium
 
-	* Initial release
+	 * Initial release
 
- -- Dell Team <support@dell.com> Mon, 29 Feb 2016 11:12:18 -0800
+ -- Dell Team <support@dell.com>  Mon, 16 Jan 2017 11:56:18 -0800


### PR DESCRIPTION
- Added dependency for opx_nas_common
- Removed opx_cpx_class_map library which may not be used
- Updated changelog