### PR TITLE
feat: OPX-3.2.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -32,7 +32,7 @@ libopx_nas_qos_la_SOURCES=src/nas_qos_cps_map_entry.cpp src/nas_qos_policer.cpp 
 libopx_nas_qos_la_CPPFLAGS=-D_FILE_OFFSET_BITS=64 -I$(top_srcdir)/inc/opx -I$(includedir)/opx
 libopx_nas_qos_la_CXXFLAGS=-std=c++11
 libopx_nas_qos_la_LDFLAGS=-shared -version-info 1:1:0
-libopx_nas_qos_la_LIBADD=-lopx_logging -lopx_nas_ndi -lopx_cps_api_common -lopx_common -lopx_nas_common
+libopx_nas_qos_la_LIBADD=-lopx_logging -lopx_cps_api_common -lopx_common -lopx_nas_common
 
 systemdconfdir=/lib/systemd/system
 systemdconf_DATA = scripts/init/*.service

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -18,7 +18,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-qos], [2.4.0+opx7], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-qos], [2.5.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+opx-nas-qos (2.5.0) unstable; urgency=medium
+
+  * Update: BST stats for BP needs sync for egr/ing types
+  * Update: Snapshot not supported, do not return stats
+  * Update: BST counter sync done only for first queue,pg,pools
+  * Update: correct the lock order
+  * Update: using nanoseconds api for collecting timestamp from epoch
+  * Update: add mutex for protection
+  * Update: S51Xx used mcast q index from 16-23.
+  * Update: Copyright year
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 05 Jun 2019 14:00:00 -0800
+
 opx-nas-qos (2.4.0+opx7) unstable; urgency=medium
 
   * Update: Remove duplicated header files from ./inc

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Dell EMC <ops-dev@lists.openswitch.net>
 Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libopx-common-dev (>= 1.4.0),
                libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),libopx-nas-common-dev (>= 6.1.0),
-               opx-ndi-api-dev (>= 6.12.0),libopx-nas-ndi-dev (>= 3.26.0)
+               opx-ndi-api-dev (>= 6.12.0)
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-nas-qos
 Vcs-Git: https://github.com/open-switch/opx-nas-qos.git

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
-Copyright: Copyright (c) 2018 Dell Inc.
+Copyright: Copyright (c) 2019 Dell Inc.
 License: Apache-2.0
 
 License: Apache-2.0

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_buffer_pool.h
+++ b/inc/opx/nas_qos_buffer_pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_buffer_profile.h
+++ b/inc/opx/nas_qos_buffer_profile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_common.h
+++ b/inc/opx/nas_qos_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -26,7 +26,7 @@
 
 #include "ietf-inet-types.h"
 #include "nas_ndi_qos.h"
-
+#include <string>
 /** NAS QOS Error Codes */
 #define NAS_QOS_E_NONE          (int)STD_ERR_OK
 #define NAS_QOS_E_MEM           (int)STD_ERR (QOS, NONMEM, 0)
@@ -181,5 +181,6 @@ void nas_qos_port_scheduler_group_association(hal_ifindex_t ifindex, ndi_port_t 
 void nas_qos_port_pool_association(hal_ifindex_t ifindex, ndi_port_t ndi_port_id, bool isAdd);
 bool nas_qos_port_is_initialized(uint32_t switch_id, hal_ifindex_t port_id);
 char * nas_qos_fmt_error_code(t_std_error ec);
-
+t_std_error nas_qos_if_name_to_if_index(hal_ifindex_t *if_index, const char *name);
+t_std_error nas_qos_get_if_index_to_name(hal_ifindex_t if_index, std::string &name);
 #endif

--- a/inc/opx/nas_qos_cps.h
+++ b/inc/opx/nas_qos_cps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_buffer_pool.h
+++ b/inc/opx/nas_qos_cps_buffer_pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_buffer_profile.h
+++ b/inc/opx/nas_qos_cps_buffer_profile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_map.h
+++ b/inc/opx/nas_qos_cps_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_policer.h
+++ b/inc/opx/nas_qos_cps_policer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_port_egress.h
+++ b/inc/opx/nas_qos_cps_port_egress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_port_ingress.h
+++ b/inc/opx/nas_qos_cps_port_ingress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_port_pool.h
+++ b/inc/opx/nas_qos_cps_port_pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_priority_group.h
+++ b/inc/opx/nas_qos_cps_priority_group.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_queue.h
+++ b/inc/opx/nas_qos_cps_queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_scheduler.h
+++ b/inc/opx/nas_qos_cps_scheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_scheduler_group.h
+++ b/inc/opx/nas_qos_cps_scheduler_group.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_cps_wred.h
+++ b/inc/opx/nas_qos_cps_wred.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_init.h
+++ b/inc/opx/nas_qos_init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_map.h
+++ b/inc/opx/nas_qos_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_map_entry.h
+++ b/inc/opx/nas_qos_map_entry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_map_util.h
+++ b/inc/opx/nas_qos_map_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_policer.h
+++ b/inc/opx/nas_qos_policer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_port_egress.h
+++ b/inc/opx/nas_qos_port_egress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_port_ingress.h
+++ b/inc/opx/nas_qos_port_ingress.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_port_pool.h
+++ b/inc/opx/nas_qos_port_pool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_priority_group.h
+++ b/inc/opx/nas_qos_priority_group.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -32,6 +32,8 @@
 #include "nas_base_obj.h"
 #include "nas_ndi_qos.h"
 #include "nas_ndi_common.h"
+#include <string>
+#include "nas_qos_common.h"
 
 class nas_qos_switch;
 
@@ -71,7 +73,7 @@ class nas_qos_priority_group : public nas::base_obj_t
     // If the priority group does not exist in a particular MMU,
     // NULL_OBJECT_ID will be stored at that MMU location.
     std::vector<ndi_obj_id_t> _shadow_ndi_obj_id_list;
-
+    std::string if_name;
 public:
 
     nas_qos_priority_group (nas_qos_switch* p_switch, nas_qos_priority_group_key_t key);
@@ -126,6 +128,8 @@ public:
         else
             return NDI_QOS_NULL_OBJECT_ID;
     }
+    std::string &get_if_name() { return if_name;}
+    void set_if_name() {nas_qos_get_if_index_to_name (key.port_id, if_name);}
 } ;
 
 inline ndi_obj_id_t nas_qos_priority_group::ndi_obj_id () const

--- a/inc/opx/nas_qos_queue.h
+++ b/inc/opx/nas_qos_queue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -33,6 +33,8 @@
 #include "nas_ndi_common.h"
 #include "nas_ndi_qos.h"
 #include "nas_ndi_obj_id_table.h"
+#include <string>
+#include "nas_qos_common.h"
 
 class nas_qos_switch;
 
@@ -83,6 +85,7 @@ class nas_qos_queue : public nas::base_obj_t
     // NULL_OBJECT_ID will be stored at that MMU location.
     std::vector<ndi_obj_id_t> _shadow_ndi_obj_id_list;
 
+    std::string if_name;
 public:
 
     nas_qos_queue (nas_qos_switch* p_switch, nas_qos_queue_key_t key);
@@ -152,6 +155,8 @@ public:
         else
             return NDI_QOS_NULL_OBJECT_ID;
     }
+    std::string &get_if_name() { return if_name;}
+    void set_if_name() {nas_qos_get_if_index_to_name (key.port_id, if_name);}
 } ;
 
 inline ndi_obj_id_t nas_qos_queue::ndi_obj_id () const

--- a/inc/opx/nas_qos_scheduler.h
+++ b/inc/opx/nas_qos_scheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_scheduler_group.h
+++ b/inc/opx/nas_qos_scheduler_group.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_switch.h
+++ b/inc/opx/nas_qos_switch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -171,6 +171,8 @@ public:
         total_queues_per_port = 0;
         cpu_queues = 0;
         max_sched_group_level = 0;
+        is_snapshot_support = false;
+        cpu_port = 0;
     };
 
     // switch wide info
@@ -179,6 +181,8 @@ public:
     uint_t total_queues_per_port;
     uint_t cpu_queues;
     uint_t max_sched_group_level;
+    bool   is_snapshot_support;
+    int    cpu_port;
 
     /************** Policers ***************/
 

--- a/inc/opx/nas_qos_switch_list.h
+++ b/inc/opx/nas_qos_switch_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/nas_qos_wred.h
+++ b/inc/opx/nas_qos_wred.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/schemae/base_qos_init.xml
+++ b/schemae/base_qos_init.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 2018 Dell Inc.
+ Copyright (c) 2019 Dell Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may
  not use this file except in compliance with the License. You may obtain

--- a/scripts/bin/base_qos_init.py
+++ b/scripts/bin/base_qos_init.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/bin/base_qos_init.sh
+++ b/scripts/bin/base_qos_init.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/init/opx-qos-init.service
+++ b/scripts/init/opx-qos-init.service
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos.py
+++ b/scripts/lib/python/nas_qos.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_buffer_pool.py
+++ b/scripts/lib/python/nas_qos_buffer_pool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_buffer_pool_stat.py
+++ b/scripts/lib/python/nas_qos_buffer_pool_stat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_buffer_profile.py
+++ b/scripts/lib/python/nas_qos_buffer_profile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_map.py
+++ b/scripts/lib/python/nas_qos_map.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_meter.py
+++ b/scripts/lib/python/nas_qos_meter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_port.py
+++ b/scripts/lib/python/nas_qos_port.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_port_pool.py
+++ b/scripts/lib/python/nas_qos_port_pool.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_priority_group.py
+++ b/scripts/lib/python/nas_qos_priority_group.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_priority_group_stat.py
+++ b/scripts/lib/python/nas_qos_priority_group_stat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_queue.py
+++ b/scripts/lib/python/nas_qos_queue.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_queue_stat.py
+++ b/scripts/lib/python/nas_qos_queue_stat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_sched_group.py
+++ b/scripts/lib/python/nas_qos_sched_group.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_scheduler.py
+++ b/scripts/lib/python/nas_qos_scheduler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_utils.py
+++ b/scripts/lib/python/nas_qos_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/scripts/lib/python/nas_qos_wred.py
+++ b/scripts/lib/python/nas_qos_wred.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_buffer_pool.cpp
+++ b/src/nas_qos_buffer_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_buffer_profile.cpp
+++ b/src/nas_qos_buffer_profile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps.cpp
+++ b/src/nas_qos_cps.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_buffer_profile.cpp
+++ b/src/nas_qos_cps_buffer_profile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -440,7 +440,7 @@ static cps_api_return_code_t nas_qos_cps_get_switch_and_buffer_profile_id(
     cps_api_object_attr_t buffer_profile_id_attr = cps_api_get_key_data(obj, BASE_QOS_BUFFER_PROFILE_ID);
 
     if (buffer_profile_id_attr == NULL) {
-        EV_LOGGING(QOS, NOTICE, "QOS", "buffer_profile id not exist in message");
+        EV_LOGGING(QOS, DEBUG, "QOS", "buffer_profile id not exist in message");
         return NAS_QOS_E_MISSING_KEY;
     }
 

--- a/src/nas_qos_cps_map.cpp
+++ b/src/nas_qos_cps_map.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_map_entry.cpp
+++ b/src/nas_qos_cps_map_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_policer.cpp
+++ b/src/nas_qos_cps_policer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_port_egress.cpp
+++ b/src/nas_qos_cps_port_egress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_port_ingress.cpp
+++ b/src/nas_qos_cps_port_ingress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_port_pool.cpp
+++ b/src/nas_qos_cps_port_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_scheduler.cpp
+++ b/src/nas_qos_cps_scheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_scheduler_group.cpp
+++ b/src/nas_qos_cps_scheduler_group.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_cps_wred.cpp
+++ b/src/nas_qos_cps_wred.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_map.cpp
+++ b/src/nas_qos_map.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_map_entry.cpp
+++ b/src/nas_qos_map_entry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_map_util.cpp
+++ b/src/nas_qos_map_util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_policer.cpp
+++ b/src/nas_qos_policer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_port_egress.cpp
+++ b/src/nas_qos_port_egress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_port_ingress.cpp
+++ b/src/nas_qos_port_ingress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_port_pool.cpp
+++ b/src/nas_qos_port_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_priority_group.cpp
+++ b/src/nas_qos_priority_group.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_queue.cpp
+++ b/src/nas_qos_queue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_scheduler.cpp
+++ b/src/nas_qos_scheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_scheduler_group.cpp
+++ b/src/nas_qos_scheduler_group.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_switch.cpp
+++ b/src/nas_qos_switch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/nas_qos_wred.cpp
+++ b/src/nas_qos_wred.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_dot1p_color_map_ut.cpp
+++ b/src/unit_test/nas_qos_dot1p_color_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_dot1p_tc_color_map_ut.cpp
+++ b/src/unit_test/nas_qos_dot1p_tc_color_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_dot1p_tc_map_ut.cpp
+++ b/src/unit_test/nas_qos_dot1p_tc_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_dscp_color_map_ut.cpp
+++ b/src/unit_test/nas_qos_dscp_color_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_dscp_tc_color_map_ut.cpp
+++ b/src/unit_test/nas_qos_dscp_tc_color_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_dscp_tc_map_ut.cpp
+++ b/src/unit_test/nas_qos_dscp_tc_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_ifindex_utl.cpp
+++ b/src/unit_test/nas_qos_ifindex_utl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_ifindex_utl.h
+++ b/src/unit_test/nas_qos_ifindex_utl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_policer_unittest.cpp
+++ b/src/unit_test/nas_qos_policer_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_port_egress_ut.cpp
+++ b/src/unit_test/nas_qos_port_egress_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_port_ingress_ut.cpp
+++ b/src/unit_test/nas_qos_port_ingress_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_queue_unittest.cpp
+++ b/src/unit_test/nas_qos_queue_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_scheduler_group_unittest.cpp
+++ b/src/unit_test/nas_qos_scheduler_group_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_scheduler_unittest.cpp
+++ b/src/unit_test/nas_qos_scheduler_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_tc_color_dot1p_map_ut.cpp
+++ b/src/unit_test/nas_qos_tc_color_dot1p_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_tc_color_dscp_map_ut.cpp
+++ b/src/unit_test/nas_qos_tc_color_dscp_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_tc_dot1p_map_ut.cpp
+++ b/src/unit_test/nas_qos_tc_dot1p_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_tc_dscp_map_ut.cpp
+++ b/src/unit_test/nas_qos_tc_dscp_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_tc_queue_map_ut.cpp
+++ b/src/unit_test/nas_qos_tc_queue_map_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/nas_qos_wred_unittest.cpp
+++ b/src/unit_test/nas_qos_wred_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_buffer_pool_example.py
+++ b/src/unit_test/scripts/nas_qos_buffer_pool_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_buffer_profile_example.py
+++ b/src/unit_test/scripts/nas_qos_buffer_profile_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_generic_cps_simple_example.py
+++ b/src/unit_test/scripts/nas_qos_generic_cps_simple_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_map_example.py
+++ b/src/unit_test/scripts/nas_qos_map_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_meter_example.py
+++ b/src/unit_test/scripts/nas_qos_meter_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_port_example.py
+++ b/src/unit_test/scripts/nas_qos_port_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_port_pool_example.py
+++ b/src/unit_test/scripts/nas_qos_port_pool_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_priority_group_example.py
+++ b/src/unit_test/scripts/nas_qos_priority_group_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_queue_example.py
+++ b/src/unit_test/scripts/nas_qos_queue_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_queue_stat_example.py
+++ b/src/unit_test/scripts/nas_qos_queue_stat_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_sched_group_example.py
+++ b/src/unit_test/scripts/nas_qos_sched_group_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_sched_group_vp_example.py
+++ b/src/unit_test/scripts/nas_qos_sched_group_vp_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_scheduler_example.py
+++ b/src/unit_test/scripts/nas_qos_scheduler_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_simple_example.py
+++ b/src/unit_test/scripts/nas_qos_simple_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/unit_test/scripts/nas_qos_wred_example.py
+++ b/src/unit_test/scripts/nas_qos_wred_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain


### PR DESCRIPTION
* Update: BST stats for BP needs sync for egr/ing types
* Update: Snapshot not supported, do not return stats
* Update: BST counter sync done only for first queue,pg,pools
* Update: correct the lock order
* Update: using nanoseconds api for collecting timestamp from epoch
* Update: add mutex for protection
* Update: S51Xx used mcast q index from 16-23.

Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>